### PR TITLE
NDS-676: Changed filesystem path for check_disk

### DIFF
--- a/nrpe.cfg
+++ b/nrpe.cfg
@@ -218,7 +218,7 @@ connection_timeout=300
 
 command[check_users]=/usr/lib/nagios/plugins/check_users -w 5 -c 10
 command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
-command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /dev/vda9
+command[check_disk]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /media/host
 command[check_zombie_procs]=/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 150 -c 200 
 


### PR DESCRIPTION
Use /media/host (host filesystem) instead of /dev/vda9, which causes problems in Docker
